### PR TITLE
feat: Foi feita criação do Serializer de Video

### DIFF
--- a/psytube/settings.py
+++ b/psytube/settings.py
@@ -133,7 +133,7 @@ STATIC_URL = "static/"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-""" AUTH_USER_MODEL = "users.User" """
+AUTH_USER_MODEL = "users.User"
 
 REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",

--- a/videos/models.py
+++ b/videos/models.py
@@ -6,7 +6,7 @@ class Video(models.Model):
     id = models.UUIDField(default=uuid.uuid4, primary_key=True, editable=False)
     title = models.CharField(max_length=128)
     thumbnail = models.CharField(max_length=128)
-    link = models.CharField(max_length=128)
+    link = models.CharField(max_length=128, unique=True)
     downloads = models.PositiveIntegerField(default=0)
     users = models.ManyToManyField(
         "users.User", on_delete=models.CASCADE, related_name="videos"

--- a/videos/serializers.py
+++ b/videos/serializers.py
@@ -1,0 +1,16 @@
+from rest_framework import serializers
+from .models import Video
+
+
+class VideoSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Video
+        exclude = ["downloads", "users"]
+        ...
+
+    def create(self, validated_data):
+        movie = Video.objects.get_or_create(**validated_data)
+        movie.downloads = movie.downloads + 1
+        return movie
+        ...
+    ...


### PR DESCRIPTION
 Foi feita criação do Serializer de Video chamada de VideoSerializer, onde foram escluidos os campos de downloads e de users, também foi sobrescrito o método create do mesmo.